### PR TITLE
Fix can_export_entity? arity (ArgumentError on /admin/users/:id in modern Discourse)

### DIFF
--- a/lib/export_csv_file_extension.rb
+++ b/lib/export_csv_file_extension.rb
@@ -38,7 +38,7 @@ end
 
 
 module ExtendedDownloadGuardianExtension
-  def can_export_entity?(entity)
+  def can_export_entity?(entity, *args)
     if entity == "user_archive" || entity == 'admin_user_archive'
       return false unless @user
 


### PR DESCRIPTION
## Problem

On current Discourse, every `/admin/users/:id` (admin user page) returns **HTTP 500**:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
plugins/discourse-legal-tools/lib/export_csv_file_extension.rb:41:in 'can_export_entity?'
app/serializers/admin_detailed_user_serializer.rb:190:in 'include_latest_export?'
```

Core's `Guardian#can_export_entity?` is now defined as `def can_export_entity?(entity, entity_id = nil, args = nil)`, and `AdminDetailedUserSerializer#include_latest_export?` calls it with **two** args: `scope.can_export_entity?("user_archive", object.id)`.

`ExtendedDownloadGuardianExtension#can_export_entity?` overrides it with a **single-argument** signature, so the 2-arg call raises `ArgumentError`, breaking the entire admin user page (and anything that serializes `latest_export`).

## Fix

Accept the extra arguments via a named splat and let the existing trailing `super` forward them to core unchanged:

```ruby
def can_export_entity?(entity, *args)
  ...
  super  # now forwards entity + the extra args to core
end
```

The override's own logic only uses `entity`; the extra positional args are only relevant to the `super` path, where they're now passed through correctly. No behaviour change for the `user_archive` / `admin_user_archive` branches.

## Test plan

- [ ] Open `/admin/users/:id` for any user — page loads (was 500).
- [ ] Extended/normal user-archive export permission logic unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)